### PR TITLE
Added XML namespace support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xml_writer"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Piotr Zolnierek <pzolnierek@gmail.com>"]
 description = "writes xml, not pretty, but faaast"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
I've needed to write XML documents with namespaced elements (for example, `<xsl:template>`).

This pull request adds two features that make it easier to use namespaces:

1. There is a `namespace` attribute which, when it contains a value, appends that prefix to all elements. This persists until it is changed or cleared. (Closing elements retain their opening namespace, using the same stack-based mechanism as the element name.)
2. There is a `ns_decl` function that writes the namespace declaration (eg `xmlns="http://www.w3.org/1999/xhtml" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"` into the currently-opened element.