### PR TITLE
Remove gendered language from documentation

### DIFF
--- a/src/xml_writer.rs
+++ b/src/xml_writer.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 pub type Result = io::Result<()>;
 
-/// The XmlWriter himself
+/// The XmlWriter itself
 pub struct XmlWriter<'a, W: Write> {
     stack: Vec<&'a str>,
     ns_stack: Vec<Option<&'a str>>,


### PR DESCRIPTION
Small change to remove some unnecessary gendering of the XmlWriter. 